### PR TITLE
Fix emails getting exposed in `To:`-field

### DIFF
--- a/emails/utils.tsx
+++ b/emails/utils.tsx
@@ -17,7 +17,8 @@ export const getInviteEmail = (
   });
 
   const inviteEmail = {
-    to: emails,
+    to: "no-reply@shera.no",
+    bcc: emails,
     from: env.EMAIL_FROM,
     subject: inviterName
       ? `${inviterName} has invited you to ${event.title}!`
@@ -66,7 +67,8 @@ export const getNewPostEmail = (
   });
 
   const newPostEmail = {
-    to: emails,
+    to: "no-reply@shera.no",
+    bcc: emails,
     from: env.EMAIL_FROM,
     subject: `New post in ${event.title}!`,
     text,
@@ -87,7 +89,8 @@ export const getUpdatedEventEmail = (
   });
 
   const updatedEventEmail = {
-    to: emails,
+    to: "no-reply@shera.no",
+    bcc: emails,
     from: env.EMAIL_FROM,
     subject: `${event.title} has been updated!`,
     text,

--- a/src/pages/api/cron/index.tsx
+++ b/src/pages/api/cron/index.tsx
@@ -198,7 +198,8 @@ const getReminderTomorrowEmail = (
   });
 
   return {
-    to: attendeeEmails,
+    to: "no-reply@shera.no",
+    bcc: attendeeEmails,
     from: env.EMAIL_FROM,
     subject: `${event.title} is happening tomorrow!`,
     text,
@@ -231,7 +232,8 @@ const getAttendance1WeekEmail = (
   );
 
   return {
-    to: attendeeEmails,
+    to: "no-reply@shera.no",
+    bcc: attendeeEmails,
     from: env.EMAIL_FROM,
     subject: `Are you going to ${event.title} in 1 week?`,
     text,
@@ -264,7 +266,8 @@ const getAttendance3DaysEmail = (
   );
 
   return {
-    to: attendeeEmails,
+    to: "no-reply@shera.no",
+    bcc: attendeeEmails,
     from: env.EMAIL_FROM,
     subject: `Are you going to ${event.title} in 3 days?`,
     text,

--- a/src/server/emailOtp.ts
+++ b/src/server/emailOtp.ts
@@ -24,7 +24,8 @@ export const EmailOtpProvider = EmailProvider({
     const host = baseUrl.replace(/^https?:\/\//, "");
 
     await emailClient.send({
-      to: email,
+      to: "no-reply@shera.no",
+      bcc: email,
       from: from,
       subject: `Authentication code: ${token}`,
       text: text({ host, token }),

--- a/src/server/emailOtp.ts
+++ b/src/server/emailOtp.ts
@@ -24,8 +24,7 @@ export const EmailOtpProvider = EmailProvider({
     const host = baseUrl.replace(/^https?:\/\//, "");
 
     await emailClient.send({
-      to: "no-reply@shera.no",
-      bcc: email,
+      to: email,
       from: from,
       subject: `Authentication code: ${token}`,
       text: text({ host, token }),


### PR DESCRIPTION
> _Closes #111_

I think this should fix the emails getting exposed :sweat_smile:

**NB!** Should probably change the mail to something else, I don't know if it's correct.