### PR TITLE
Add button to download .ics file (iCalendar)

### DIFF
--- a/src/components/event/Event.tsx
+++ b/src/components/event/Event.tsx
@@ -12,6 +12,7 @@ import dynamic from "next/dynamic";
 import { Attendance } from "./Attendance";
 import NewPost from "../post/NewPost";
 import PostList from "../post/PostList";
+import ICalendar from "./ICalendar";
 
 const Invite = dynamic(() => import("../invite/Invite"), {
   ssr: false,
@@ -69,6 +70,7 @@ export const Event = ({ publicId }: Props) => {
       <div className="flex flex-wrap justify-start gap-2">
         <Invite event={event} />
         <GoogleCalendar event={event} />
+        <ICalendar event={event} />
         <NewPost publicId={publicId} isHost={isHost} />
       </div>
 

--- a/src/components/event/GoogleCalendar.tsx
+++ b/src/components/event/GoogleCalendar.tsx
@@ -34,9 +34,10 @@ const GoogleCalendar = (props: GoogleCalendarProps) => {
   const url = `https://www.google.com/calendar/render?action=TEMPLATE&text=${title}&details=${description}&location=${location}&dates=${time}&ctz=${timezone}`;
 
   return (
-    <Button asChild variant={"outline"}>
+    <Button asChild variant={"outline"} style={{ gap: 8 }}>
       <a className="link" target="_blank" href={url} rel="noopener noreferrer">
         <Calendar />
+        Google Calendar
       </a>
     </Button>
   );

--- a/src/components/event/ICalendar.tsx
+++ b/src/components/event/ICalendar.tsx
@@ -1,0 +1,69 @@
+import type { Event } from "@prisma/client";
+import { add } from "date-fns";
+import type { User } from "next-auth";
+import { Button } from "../ui/button";
+import { Calendar } from "lucide-react";
+import { fullEventId } from "../../utils/event";
+import { useEffect, useState } from "react";
+
+type ICalendarProps = {
+  event: Event & {
+    host: User;
+  };
+};
+
+const ICalendar = (props: ICalendarProps) => {
+  const { event } = props;
+
+  const sheraLink = `https://shera.no/events/${fullEventId(event)}`;
+
+  const location = event.place ?? "";
+
+  const createdAt = event.createdAt.toISOString().replace(/-|:|\.\d+/g, "");
+  const startTime = event.dateTime.toISOString().replace(/-|:|\.\d+/g, "");
+  const endTime = add(event.dateTime, { hours: 1 })
+    .toISOString()
+    .replace(/-|:|\.\d+/g, "");
+
+  const icsContent = `
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:shera.no
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VEVENT
+UID:${event.eventId}@shera.no
+DTSTAMP:${createdAt}
+DTSTART:${startTime}
+DTEND:${endTime}
+SUMMARY:${event.title}
+DESCRIPTION:${event.description.replace(/\n/g, "\\n")}
+URL:${sheraLink}
+LOCATION:${location}
+END:VEVENT
+END:VCALENDAR
+    `.trim();
+
+  const [icsCalUrl, setIcsCalUrl] = useState<string>("");
+
+  useEffect(() => {
+    const blob = new Blob([icsContent], { type: "text/calendar" });
+    const url = URL.createObjectURL(blob);
+    setIcsCalUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [icsContent]);
+
+  return (
+    <Button asChild variant={"outline"} style={{ gap: 8 }}>
+      <a className="link" href={icsCalUrl} download="shera-event.ics">
+        <Calendar />
+        <span>iCal</span>
+      </a>
+    </Button>
+  );
+};
+
+export default ICalendar;


### PR DESCRIPTION
This new button lets the user download a .ics file which can be imported to (almost) any calendar app.

I have only tested importing the file in Apple's calendar app on desktop.

Fixes #107

Test event:

<img width="667" alt="Skjermbilde 2025-01-30 kl  23 44 49" src="https://github.com/user-attachments/assets/35f2cafd-0b63-4980-9c4f-e7145f313107" />

Imported:

<img width="572" alt="Skjermbilde 2025-01-30 kl  23 45 20" src="https://github.com/user-attachments/assets/adb72444-b8da-413d-99c7-8d0d52e823ac" />

