### PR TITLE
Ical tweaks

### DIFF
--- a/src/components/event/GoogleCalendar.tsx
+++ b/src/components/event/GoogleCalendar.tsx
@@ -34,7 +34,7 @@ const GoogleCalendar = (props: GoogleCalendarProps) => {
   const url = `https://www.google.com/calendar/render?action=TEMPLATE&text=${title}&details=${description}&location=${location}&dates=${time}&ctz=${timezone}`;
 
   return (
-    <Button asChild variant={"outline"} style={{ gap: 8 }}>
+    <Button asChild variant={"outline"} className="gap-2">
       <a className="link" target="_blank" href={url} rel="noopener noreferrer">
         <Calendar />
         Google Calendar

--- a/src/components/event/GoogleCalendar.tsx
+++ b/src/components/event/GoogleCalendar.tsx
@@ -18,7 +18,7 @@ const GoogleCalendar = (props: GoogleCalendarProps) => {
   const sheraLink = `https://shera.no/events/${fullEventId(event)}`;
 
   const description = encodeURIComponent(
-    `${sheraLink}\n\n${event.description}`,
+    `${event.description}\n\n${sheraLink}`,
   );
 
   const location = encodeURIComponent(event.place ?? "");

--- a/src/components/event/ICalendar.tsx
+++ b/src/components/event/ICalendar.tsx
@@ -60,9 +60,11 @@ END:VCALENDAR
     };
   }, [icsContent]);
 
+  const filename = `shera-${fullEventId(event)}.ics`;
+
   return (
     <Button asChild variant={"outline"} className="gap-2">
-      <a className="link" href={icsCalUrl} download="shera-event.ics">
+      <a className="link" href={icsCalUrl} download={filename}>
         <Calendar />
         <span>iCal</span>
       </a>

--- a/src/components/event/ICalendar.tsx
+++ b/src/components/event/ICalendar.tsx
@@ -18,6 +18,10 @@ const ICalendar = (props: ICalendarProps) => {
   const sheraLink = `https://shera.no/events/${fullEventId(event)}`;
 
   const location = event.place ?? "";
+  const description = `${event.description}\n\n${sheraLink}`.replace(
+    /\n/g,
+    "\\n",
+  );
 
   const createdAt = event.createdAt.toISOString().replace(/-|:|\.\d+/g, "");
   const startTime = event.dateTime.toISOString().replace(/-|:|\.\d+/g, "");
@@ -37,7 +41,7 @@ DTSTAMP:${createdAt}
 DTSTART:${startTime}
 DTEND:${endTime}
 SUMMARY:${event.title}
-DESCRIPTION:${event.description.replace(/\n/g, "\\n")}
+DESCRIPTION:${description}
 URL:${sheraLink}
 LOCATION:${location}
 END:VEVENT

--- a/src/components/event/ICalendar.tsx
+++ b/src/components/event/ICalendar.tsx
@@ -57,7 +57,7 @@ END:VCALENDAR
   }, [icsContent]);
 
   return (
-    <Button asChild variant={"outline"} style={{ gap: 8 }}>
+    <Button asChild variant={"outline"} className="gap-2">
       <a className="link" href={icsCalUrl} download="shera-event.ics">
         <Calendar />
         <span>iCal</span>


### PR DESCRIPTION
Some minor tweaks to #116 

- Use tailwind to style the buttons
- Add link to the description (this will double on calendar providers that append the URL, but for now I think that is better than no URL).
- Use the event title as the filename

In addition I changed from having the URL first in the google event to last, like in the .ics. 