### PR TITLE
fix missing posthog variables in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,7 @@ EMAIL_FROM=Shera <post@shera.no>
 
 BASE_URL=localhost:3000/
 CRON_SECRET=local
+
+# Posthog
+NEXT_PUBLIC_POSTHOG_HOST=local
+NEXT_PUBLIC_POSTHOG_KEY=local


### PR DESCRIPTION
Closes issue #123.