### PR TITLE
Tweak upcoming and future labels

### DIFF
--- a/src/components/myEvents/MyEvents.tsx
+++ b/src/components/myEvents/MyEvents.tsx
@@ -52,11 +52,11 @@ export const MyEvents = () => {
         </div>
       )}
 
-      <h2>Upcoming</h2>
+      {events?.upcoming && events.upcoming.length > 0 && <h2>Upcoming</h2>}
       {events?.upcoming.map((event) => (
         <EventRow event={event.event} key={`event-${event.event.publicId}`} />
       ))}
-      <h2>Finished</h2>
+      {events?.finished && events.finished.length > 0 && <h2>Finished</h2>}
       {events?.finished.map((event) => (
         <EventRow event={event.event} key={`event-${event.event.publicId}`} />
       ))}

--- a/src/components/myEvents/MyEvents.tsx
+++ b/src/components/myEvents/MyEvents.tsx
@@ -52,11 +52,15 @@ export const MyEvents = () => {
         </div>
       )}
 
-      {events?.upcoming && events.upcoming.length > 0 && <h2>Upcoming</h2>}
+      {events?.upcoming && events.upcoming.length > 0 && (
+        <h2 className="text-primary">Upcoming</h2>
+      )}
       {events?.upcoming.map((event) => (
         <EventRow event={event.event} key={`event-${event.event.publicId}`} />
       ))}
-      {events?.finished && events.finished.length > 0 && <h2>Finished</h2>}
+      {events?.finished && events.finished.length > 0 && (
+        <h2 className="text-primary">Finished</h2>
+      )}
       {events?.finished.map((event) => (
         <EventRow event={event.event} key={`event-${event.event.publicId}`} />
       ))}

--- a/src/components/myEvents/MyEvents.tsx
+++ b/src/components/myEvents/MyEvents.tsx
@@ -30,7 +30,7 @@ export const MyEvents = () => {
   );
 
   return (
-    <div className="flex flex-col gap-8 p-4">
+    <div className="flex flex-col gap-4 p-4">
       <div className="flex items-center justify-between">
         <h1 className="py-2 text-4xl font-extrabold text-primary">Events</h1>
         <Button asChild variant="outline">
@@ -53,17 +53,31 @@ export const MyEvents = () => {
       )}
 
       {events?.upcoming && events.upcoming.length > 0 && (
-        <h2 className="text-primary">Upcoming</h2>
+        <div>
+          <h2 className="pb-2 text-primary">Upcoming</h2>
+          <div className="flex flex-col gap-8">
+            {events.upcoming.map((event) => (
+              <EventRow
+                event={event.event}
+                key={`event-${event.event.publicId}`}
+              />
+            ))}
+          </div>
+        </div>
       )}
-      {events?.upcoming.map((event) => (
-        <EventRow event={event.event} key={`event-${event.event.publicId}`} />
-      ))}
       {events?.finished && events.finished.length > 0 && (
-        <h2 className="text-primary">Finished</h2>
+        <div>
+          <h2 className="pb-2 text-primary">Finished</h2>
+          <div className="flex flex-col gap-8">
+            {events.finished.map((event) => (
+              <EventRow
+                event={event.event}
+                key={`event-${event.event.publicId}`}
+              />
+            ))}
+          </div>
+        </div>
       )}
-      {events?.finished.map((event) => (
-        <EventRow event={event.event} key={`event-${event.event.publicId}`} />
-      ))}
 
       {isSuccess && (
         <Button asChild variant="outline">


### PR DESCRIPTION
Only display the labels when we have content, not during loading. 
Give the labels a color.
Fix the spacing a bit. 