### PR TITLE
Tiny visual indication that event is hosted by logged in user

### DIFF
--- a/src/components/myEvents/MyEvents.tsx
+++ b/src/components/myEvents/MyEvents.tsx
@@ -14,6 +14,7 @@ import {
 import { useSession } from "next-auth/react";
 import { type EventRowProps } from "~/utils/types";
 import { infoBoxFormatHostNames } from "../../../emails/utils";
+import {cn} from "~/utils/cn";
 
 export const MyEvents = () => {
   const session = useSession();
@@ -134,10 +135,10 @@ const EventRow = ({ event, currentUserId}: EventRowProps) => {
               )}
               {hostNames && (
                 <div className="flex items-center gap-2">
-                  <Crown size={16} className={isHost ? "text-primary" : ""} />
+                  <Crown size={16} className={cn(isHost && "text-primary")} />
 
                   <div>
-                    <p className={"w-72 overflow-hidden text-ellipsis text-nowrap" + (isHost ? " text-primary font-bold" : "")}>
+                    <p className={cn("w-72 overflow-hidden text-ellipsis text-nowrap", isHost && "text-primary underline")}>
                       {hostNames}
                     </p>
                   </div>

--- a/src/components/myEvents/MyEvents.tsx
+++ b/src/components/myEvents/MyEvents.tsx
@@ -17,9 +17,10 @@ import { infoBoxFormatHostNames } from "../../../emails/utils";
 
 export const MyEvents = () => {
   const session = useSession();
+  const userId = session.data?.user.id ?? "";
   const { data: events, isSuccess } = api.events.myEvents.useQuery(
     {
-      userId: session.data?.user.id ?? "",
+      userId,
     },
     {
       enabled: !!session.data?.user.id,
@@ -59,8 +60,9 @@ export const MyEvents = () => {
           <div className="flex flex-col gap-8">
             {events.upcoming.map((event) => (
               <EventRow
-                event={event.event}
-                key={`event-${event.event.publicId}`}
+                event={event}
+                currentUserId={userId}
+                key={`event-${event.publicId}`}
               />
             ))}
           </div>
@@ -71,9 +73,10 @@ export const MyEvents = () => {
           <h2 className="pb-2 text-primary">Finished</h2>
           <div className="flex flex-col gap-8">
             {events.finished.map((event) => (
-              <EventRow
-                event={event.event}
-                key={`event-${event.event.publicId}`}
+            <EventRow
+                event={event}
+                currentUserId={userId}
+                key={`event-${event.publicId}`}
               />
             ))}
           </div>
@@ -89,9 +92,10 @@ export const MyEvents = () => {
   );
 };
 
-const EventRow = ({ event }: EventRowProps) => {
+const EventRow = ({ event, currentUserId}: EventRowProps) => {
   const hostNames = infoBoxFormatHostNames(event.hosts);
 
+  const isHost = event.hosts.some((host) => host.id === currentUserId);
   return (
     <div className="flex flex-col md:flex-row">
       <div className="w-32 pb-2">
@@ -130,10 +134,10 @@ const EventRow = ({ event }: EventRowProps) => {
               )}
               {hostNames && (
                 <div className="flex items-center gap-2">
-                  <Crown size={16} />
+                  <Crown size={16} className={isHost ? "text-primary" : ""} />
 
                   <div>
-                    <p className="w-72 overflow-hidden text-ellipsis text-nowrap">
+                    <p className={"w-72 overflow-hidden text-ellipsis text-nowrap" + (isHost ? " text-primary font-bold" : "")}>
                       {hostNames}
                     </p>
                   </div>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -11,8 +11,14 @@ export type Friend = {
   }>;
 };
 
+export type EventWithAttendeesAndHosts = Event & {
+  hosts: User[];
+  attendees: Attendee[];
+};
+
 export type EventRowProps = {
-  event: Event & { hosts: User[]; attendees: Attendee[] };
+  event: EventWithAttendeesAndHosts;
+  currentUserId: string;
 };
 
 export type EventWithHosts = Event & { hosts: User[] };


### PR DESCRIPTION
When a logged in user views events, there will be a tiny visual indication that the current user is (one of) the host(s).
- Crown and hosts text will be bold and with default text color.

<img width="3800" height="1866" alt="image" src="https://github.com/user-attachments/assets/32a87597-eb4e-4175-af62-cfb8eb4bb96f" />

Other changes:
- Add currentUser to `EventRowProps` used for the EventRow component
- extract repeatedly used sub-type `Event & { hosts: User[]; attendees: Attendee[];}`
- 