### PR TITLE
Utilise sendgrinds multiple method

### DIFF
--- a/emails/getEmails.tsx
+++ b/emails/getEmails.tsx
@@ -22,8 +22,7 @@ export const getInviteEmail = (
   });
 
   const inviteEmail = {
-    to: "no-reply@shera.no",
-    bcc: emails,
+    to: emails,
     from: env.EMAIL_FROM,
     subject: inviterName
       ? `${inviterName} has invited you to ${event.title}!`
@@ -100,8 +99,7 @@ export const getUpdatedEventEmail = (
   });
 
   const updatedEventEmail = {
-    to: "no-reply@shera.no",
-    bcc: emails,
+    to: emails,
     from: env.EMAIL_FROM,
     subject: `${event.title} has been updated!`,
     text,

--- a/src/server/api/routers/events.ts
+++ b/src/server/api/routers/events.ts
@@ -131,7 +131,7 @@ export const eventsRouter = createTRPCRouter({
             attendeeEmails,
           );
 
-          await emailClient.send(updatedEventEmail);
+          await emailClient.sendMultiple(updatedEventEmail);
         }
       }
 


### PR DESCRIPTION
Sendgrind's `sendMultiple` is, according to docs, splitting the "to" - list into individual emails.

https://github.com/sendgrid/sendgrid-nodejs/blob/b3b2092b7a150ffc5d68c9bb6575810a5827f69e/docs/use-cases/single-email-multiple-recipients.md

fixing #113 