### PR TITLE
feat: Add timezone to event-date info

### DIFF
--- a/emails/components/EventEmail.tsx
+++ b/emails/components/EventEmail.tsx
@@ -126,7 +126,7 @@ const InfoBox = ({ event }: InfoBoxProps) => {
         </Column>
         <Column>
           <Text className="m-0">
-            {formatInTimeZone(event.dateTime, event.timeZone, "H:mm")}
+            {formatInTimeZone(event.dateTime, event.timeZone, "H:mm 000")}
           </Text>
         </Column>
       </Row>

--- a/src/components/event/Event.tsx
+++ b/src/components/event/Event.tsx
@@ -44,7 +44,7 @@ export const Event = ({ publicId }: Props) => {
       <div className="text-lg">
         <div className="flex items-center gap-2">
           <WorkingClock date={event.dateTime} size={16} />
-          <p>{format(event.dateTime, "EEEE, LLLL do, H:mm")}</p>
+          <p>{format(event.dateTime, "EEEE, LLLL do, H:mm OOO")}</p>
         </div>
         {event.place && (
           <div className="flex items-center gap-2">

--- a/src/components/myEvents/MyEvents.tsx
+++ b/src/components/myEvents/MyEvents.tsx
@@ -100,7 +100,7 @@ const EventRow = ({ event, currentUserId}: EventRowProps) => {
   return (
     <div className="flex flex-col md:flex-row">
       <div className="w-32 pb-2">
-        <p>{format(event.dateTime, "d. MMM")}</p>
+        <p>{format(event.dateTime, "d. MMM 000")}</p>
         <p className="text-primary/50">{format(event.dateTime, "eeee")}</p>
       </div>
 


### PR DESCRIPTION
> Closes #160 

This PR will display the time to the user in their current local timezone with the timezone behind aswell. 

Regarding the email it's still sent in the timezone of the hosts invite - aka if I'm the host in GMT+1 and send an invite to you in GMT+8, it'll say GMT+1 in the email. 

Existing events will show the new timezone as well as update the time and timezone corresponding to their local timezone.

### Screenshots

**Date for user in GMT+1:**

<img width="635" height="191" alt="Screenshot 2026-03-12 at 20 06 45" src="https://github.com/user-attachments/assets/7694d6b9-523f-4073-9e78-f3ccf75f2dc2" />

<img width="793" height="392" alt="Screenshot 2026-03-12 at 20 06 39" src="https://github.com/user-attachments/assets/480bb80d-89da-43a2-8465-5ee581a1971d" />

**Date for user in GMT+8:**

<img width="913" height="387" alt="Screenshot 2026-03-12 at 20 07 41" src="https://github.com/user-attachments/assets/efd88855-c5ac-41c0-8052-7b43145cf9d9" />

<img width="904" height="254" alt="Screenshot 2026-03-12 at 20 07 34" src="https://github.com/user-attachments/assets/b2ddee1f-c55a-4185-887f-e7cd08b2424d" />

**Email for invited user in GMT+8:**

<img width="154" height="54" alt="Screenshot 2026-03-18 at 20 15 13" src="https://github.com/user-attachments/assets/85e9d83f-6be9-4cd8-b8ae-f2f0c75a0b56" />
